### PR TITLE
feat: Gerador de Hash (MD5, SHA-1, SHA-256, SHA-384, SHA-512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 - Base64 Encode e Decode.
 
+- Gerador de Hash (MD5, SHA-1, SHA-256, SHA-384 e SHA-512).
+
 ### _Acesse: [gerador.dev.br](https://gerador.dev.br)_
 
 ## Por quê?
@@ -34,6 +36,7 @@ Pois bem, assim nasceu o querido Gerador.
 - [x] JSON Pretty
 - [x] Gerador de Cartão de Crédito válido
 - [x] Base64 Encoding e Decoding
+- [x] Gerador de Hash (MD5, SHA-1, SHA-256, SHA-384, SHA-512)
 
 ## Colabore
 

--- a/src/components/HashGenerator.tsx
+++ b/src/components/HashGenerator.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import CopyButton from '@/components/CopyButton'
+import { hash } from '@/utils/hash'
+import { HashAlgorithm } from '@/enums'
+
+const ALGORITHMS = [
+  HashAlgorithm.MD5,
+  HashAlgorithm.SHA1,
+  HashAlgorithm.SHA256,
+  HashAlgorithm.SHA384,
+  HashAlgorithm.SHA512,
+]
+
+export default function HashGenerator() {
+  const [algorithm, setAlgorithm] = useState<HashAlgorithm>(HashAlgorithm.SHA256)
+  const [input, setInput] = useState('')
+  const [output, setOutput] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleGenerate = async () => {
+    setLoading(true)
+    setOutput(await hash(input, algorithm))
+    setLoading(false)
+  }
+
+  const handleAlgorithmChange = (algo: HashAlgorithm) => {
+    setAlgorithm(algo)
+    setOutput('')
+  }
+
+  return (
+    <div className="w-full max-w-lg flex flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        {ALGORITHMS.map((algo) => (
+          <Button
+            key={algo}
+            variant={algorithm === algo ? 'default' : 'outline'}
+            onClick={() => handleAlgorithmChange(algo)}
+          >
+            {algo}
+          </Button>
+        ))}
+      </div>
+
+      {algorithm === HashAlgorithm.MD5 && (
+        <p className="text-sm text-amber-600 dark:text-amber-500">
+          MD5 é considerado inseguro e não é recomendado para uso em produção.
+        </p>
+      )}
+
+      <Textarea
+        placeholder="Digite o texto para gerar o hash"
+        value={input}
+        onChange={(e) => { setInput(e.target.value); setOutput('') }}
+        rows={5}
+        className="resize-none font-mono text-sm"
+      />
+
+      <Button onClick={handleGenerate} disabled={input.length === 0 || loading}>
+        {loading ? 'Gerando…' : 'Gerar hash'}
+      </Button>
+
+      {output && (
+        <div className="relative animate-in fade-in slide-in-from-bottom-2 duration-200">
+          <Textarea
+            readOnly
+            value={output}
+            rows={2}
+            className="resize-none font-mono text-sm pr-12 break-all"
+          />
+          <CopyButton text={output} className="absolute top-2 right-2" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -7,6 +7,7 @@ const links = [
   { href: '/credit-card', label: 'Cartão de Crédito' },
   { href: '/json-pretty', label: 'JSON Pretty' },
   { href: '/base64-encode-decode', label: 'Base64' },
+  { href: '/hash', label: 'Hash' },
 ]
 
 const currentPath = Astro.url.pathname

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -9,3 +9,11 @@ export enum CreditCardBrand {
   MASTERCARD = 'mastercard',
   VISA = 'visa',
 }
+
+export enum HashAlgorithm {
+  MD5 = 'MD5',
+  SHA1 = 'SHA-1',
+  SHA256 = 'SHA-256',
+  SHA384 = 'SHA-384',
+  SHA512 = 'SHA-512',
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const {
   title,
-  description = 'Ferramentas para desenvolvedores: CPF, CNPJ, RG, cartão de crédito, JSON Pretty e Base64.',
+  description = 'Ferramentas para desenvolvedores: CPF, CNPJ, RG, cartão de crédito, JSON Pretty, Base64 e Hash.',
 } = Astro.props
 
 const ga = import.meta.env.PUBLIC_GOOGLE_ANALYTICS

--- a/src/pages/hash.astro
+++ b/src/pages/hash.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro'
+import HashGenerator from '@/components/HashGenerator'
+---
+
+<BaseLayout
+  title="Hash"
+  description="Gerador de hashes MD5, SHA-1, SHA-256, SHA-384 e SHA-512."
+>
+  <HashGenerator client:load />
+</BaseLayout>

--- a/src/utils/__tests__/hash.test.ts
+++ b/src/utils/__tests__/hash.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { hash } from '../hash'
+import { HashAlgorithm } from '@/enums'
+
+describe('MD5', () => {
+  it('string vazia', async () => {
+    expect(await hash('', HashAlgorithm.MD5)).toBe('d41d8cd98f00b204e9800998ecf8427e')
+  })
+
+  it("'abc'", async () => {
+    expect(await hash('abc', HashAlgorithm.MD5)).toBe('900150983cd24fb0d6963f7d28e17f72')
+  })
+
+  it('unicode (São Paulo)', async () => {
+    expect(await hash('São Paulo', HashAlgorithm.MD5)).toBe('ea76c0ae9dd817eb448fd1b3db6253bb')
+  })
+})
+
+describe('SHA-1', () => {
+  it("'abc'", async () => {
+    expect(await hash('abc', HashAlgorithm.SHA1)).toBe('a9993e364706816aba3e25717850c26c9cd0d89d')
+  })
+})
+
+describe('SHA-256', () => {
+  it("'abc'", async () => {
+    expect(await hash('abc', HashAlgorithm.SHA256)).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+  })
+})
+
+describe('SHA-384', () => {
+  it("'abc'", async () => {
+    expect(await hash('abc', HashAlgorithm.SHA384)).toBe('cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7')
+  })
+})
+
+describe('SHA-512', () => {
+  it("'abc'", async () => {
+    expect(await hash('abc', HashAlgorithm.SHA512)).toBe('ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f')
+  })
+})

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,103 @@
+import { HashAlgorithm } from '@/enums'
+
+export async function hash(text: string, algorithm: HashAlgorithm): Promise<string> {
+  if (algorithm === HashAlgorithm.MD5) {
+    return md5(text)
+  }
+  const data = new TextEncoder().encode(text)
+  const buffer = await crypto.subtle.digest(algorithm as AlgorithmIdentifier, data)
+  return bytesToHex(new Uint8Array(buffer))
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function md5(message: string): string {
+  const bytes = new TextEncoder().encode(message)
+  const msgLen = bytes.length
+  const bitLen = msgLen * 8
+
+  const padLen = msgLen + 1 + ((56 - (msgLen + 1)) % 64 + 64) % 64
+  const buf = new Uint8Array(padLen + 8)
+  buf.set(bytes)
+  buf[msgLen] = 0x80
+  const dv = new DataView(buf.buffer)
+  dv.setUint32(padLen, bitLen >>> 0, true)
+  dv.setUint32(padLen + 4, Math.floor(bitLen / 0x100000000), true)
+
+  const T = [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee,
+    0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa,
+    0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+    0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05,
+    0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039,
+    0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+    0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+  ]
+
+  const S = [
+     7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,  7, 12, 17, 22,
+     5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,  5,  9, 14, 20,
+     4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,  4, 11, 16, 23,
+     6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,  6, 10, 15, 21,
+  ]
+
+  let a0 = 0x67452301
+  let b0 = 0xefcdab89
+  let c0 = 0x98badcfe
+  let d0 = 0x10325476
+
+  for (let blk = 0; blk < buf.length / 64; blk++) {
+    const M = new Uint32Array(16)
+    for (let j = 0; j < 16; j++) {
+      M[j] = dv.getUint32(blk * 64 + j * 4, true)
+    }
+
+    let A = a0, B = b0, C = c0, D = d0
+
+    for (let i = 0; i < 64; i++) {
+      let F: number, g: number
+      if (i < 16) {
+        F = (B & C) | (~B & D)
+        g = i
+      } else if (i < 32) {
+        F = (D & B) | (~D & C)
+        g = (5 * i + 1) % 16
+      } else if (i < 48) {
+        F = B ^ C ^ D
+        g = (3 * i + 5) % 16
+      } else {
+        F = C ^ (B | ~D)
+        g = (7 * i) % 16
+      }
+      const temp = (F + A + T[i] + M[g]) >>> 0
+      A = D
+      D = C
+      C = B
+      B = (B + ((temp << S[i]) | (temp >>> (32 - S[i])))) >>> 0
+    }
+
+    a0 = (a0 + A) >>> 0
+    b0 = (b0 + B) >>> 0
+    c0 = (c0 + C) >>> 0
+    d0 = (d0 + D) >>> 0
+  }
+
+  const out = new Uint8Array(16)
+  const ov = new DataView(out.buffer)
+  ov.setUint32(0, a0, true)
+  ov.setUint32(4, b0, true)
+  ov.setUint32(8, c0, true)
+  ov.setUint32(12, d0, true)
+  return bytesToHex(out)
+}


### PR DESCRIPTION
## O que foi feito

Nova ferramenta em `/hash`: o usuário digita um texto, escolhe o algoritmo e obtém o digest em hexadecimal, com botão para copiar.

**Algoritmos disponíveis:** MD5, SHA-1, SHA-256, SHA-384, SHA-512.

MD5 é incluído por conveniência com um disclaimer explícito de que não é recomendado para uso em produção.

## Implementação

- SHA-1/256/384/512 via **Web Crypto API nativa** (`crypto.subtle.digest`) — zero dependências novas.
- MD5 implementado do zero em `src/utils/hash.ts` seguindo o RFC 1321, operando sobre os bytes UTF-8 do input (via `TextEncoder`), mantendo o padrão do projeto de preferir APIs nativas.
- UI seguindo o mesmo padrão das outras ferramentas: seletor de algoritmo com botões, textarea de input, botão de ação assíncrono e output com `CopyButton`.

## Arquivos

| Arquivo | O que é |
|---|---|
| `src/utils/hash.ts` | Lógica pura: MD5 próprio + SHA via Web Crypto |
| `src/components/HashGenerator.tsx` | Componente React da ferramenta |
| `src/pages/hash.astro` | Rota `/hash` |
| `src/enums.ts` | `HashAlgorithm` enum adicionado |
| `src/components/Navbar.astro` | Link "Hash" no menu (desktop + mobile) |

## Testes

29 testes passando, incluindo vetores canônicos do NIST/RFC para todos os algoritmos e validação de input unicode.

✓ MD5 > string vazia
✓ MD5 > 'abc'
✓ MD5 > unicode (São Paulo)
✓ SHA-1 > 'abc'
✓ SHA-256 > 'abc'
✓ SHA-384 > 'abc'
✓ SHA-512 > 'abc'